### PR TITLE
Support reading the phpcs_path from the user settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Specify custom PHPCS/PHPCBF paths in settings.json:
   "lsp": {
     "phpcs": {
       "settings": {
-        "phpcsPath": "/custom/path/to/phpcs",
-        "phpcbfPath": "/custom/path/to/phpcbf"
+        "phpcs_path": "/custom/path/to/phpcs",
+        "phpcbf_path": "/custom/path/to/phpcbf"
       }
     }
   }


### PR DESCRIPTION
Allows you to set the custom path in the settings and passes it to the language server.

I changed it to `phpcs_path` from what was in the readme since all of the other zed settings are snake case.

Fixes #14