### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Create PHP files with intentional PHPCS violations in `test-files/` to verify di
 ## Resources & Credits
 
 ### Learn More
-- [PHP_CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki)
+- [PHP_CodeSniffer Documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki)
 - [PSR Standards](https://www.php-fig.org/psr/)
 - [Zed Editor Documentation](https://zed.dev/docs)
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932