### PR TITLE
ci: 👷 adopt self-healing publish-zed-extension action

### DIFF
--- a/.github/actions/publish-zed-extension/README.md
+++ b/.github/actions/publish-zed-extension/README.md
@@ -1,0 +1,78 @@
+# publish-zed-extension
+
+Composite GitHub Action that opens or updates a PR in
+[`zed-industries/extensions`](https://github.com/zed-industries/extensions)
+to bump this extension's submodule pointer and version.
+
+## Why this exists (vs. `huacnlee/zed-extension-action`)
+
+The upstream `huacnlee/zed-extension-action` creates a new branch with a
+timestamped name on every run (`update-<ext>-<unix-time>`), which means
+re-running the publish step opens a duplicate PR every time instead of updating
+the in-flight one.
+
+This action uses a deterministic branch name (`bump-<ext>-<version>`) and
+checks for an existing open PR before deciding whether to create a new one or
+force-push the existing branch. Net effect: **at most one open PR per version,
+ever** — re-runs update the existing PR.
+
+## Inputs
+
+| Name              | Required | Description                                                                 |
+| ----------------- | -------- | --------------------------------------------------------------------------- |
+| `extension-name`  | yes      | Name as registered upstream (e.g., `laravel`).                              |
+| `version`         | yes      | Version without `v` prefix. A tag `v<version>` must exist on the source repo. |
+| `push-to`         | yes      | Fork of `zed-industries/extensions` to push to (e.g., `mike-bronner/extensions`). Must already exist. |
+| `upstream-repo`   | no       | Defaults to `zed-industries/extensions`.                                    |
+| `committer-token` | yes      | PAT with `repo` + `workflow` scopes on the fork.                            |
+| `signing-key`     | no       | SSH private key for signing commits. Public key must be on the PAT owner's GitHub account as a *Signing Key*. |
+
+## Behavior
+
+1. Looks up any open PR from `<fork-owner>:bump-<ext>-<version>` to upstream.
+2. Clones the fork, syncs its default branch with upstream (force-push), then
+   builds the bump branch fresh from upstream's default branch.
+3. Initializes the `extensions/<ext>` submodule, fetches tag `v<version>`,
+   checks it out.
+4. Updates `version = "<version>"` inside the `[<ext>]` section of
+   `extensions.toml` (scoped — won't touch other entries).
+5. Commits both changes if anything actually changed (idempotent).
+6. Force-pushes the bump branch.
+7. Creates a new PR if none existed, otherwise the force-push updates the
+   existing PR automatically.
+
+## Prerequisites
+
+- Fork `zed-industries/extensions` to the `push-to` owner.
+- Ensure the fork's `.gitmodules` for `extensions/<ext>` points at the source
+  repo (true by default if the fork was made cleanly).
+- Add a `ZED_PUBLISHING_TOKEN` repo secret with a PAT that has `repo` +
+  `workflow` scopes. This repo's `release.yml` also uses it as the push token
+  for the version-bump commit (in place of a separate `OWNER_PAT`), so the PAT
+  must have write access to **both** the source repo and the `push-to` fork. A
+  classic PAT owned by the account that owns both covers this automatically; a
+  fine-grained PAT must list both repos with Contents + Workflows = Read/Write.
+- Push tag `<version>` (or `v<version>`) to the source repo *before* this
+  action runs. The script auto-detects which form exists. In this repo's
+  `release.yml`, the `update-version` job handles that and `publish` depends
+  on it.
+- (Optional) For signed/verified commits: generate a dedicated SSH key,
+  register the public key on the PAT owner's GitHub account under *Settings →
+  SSH and GPG keys* with **Key type: Signing Key**, and store the private key
+  as the `COMMIT_SIGNING_SSH_KEY` secret. Without this, commits will appear
+  as "Unverified" on GitHub.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    ref: main
+
+- uses: ./.github/actions/publish-zed-extension
+  with:
+    extension-name: phpcs
+    version: ${{ needs.update-version.outputs.new_version }}
+    push-to: mike-bronner/extensions
+    committer-token: ${{ secrets.ZED_PUBLISHING_TOKEN }}
+```

--- a/.github/actions/publish-zed-extension/action.yml
+++ b/.github/actions/publish-zed-extension/action.yml
@@ -1,0 +1,37 @@
+name: 'Publish Zed Extension'
+description: 'Open or update a PR in zed-industries/extensions for a new release. Reuses the same branch per version, so re-runs update the existing PR rather than creating duplicates.'
+
+inputs:
+  extension-name:
+    description: 'Name of the extension as registered in the upstream extensions repo (e.g., "laravel")'
+    required: true
+  version:
+    description: 'Version number to publish, without "v" prefix (e.g., "0.1.15"). Must already exist as tag "v<version>" on the source repo.'
+    required: true
+  push-to:
+    description: 'Fork of the upstream extensions repo to push to, in "owner/repo" form (e.g., "mike-bronner/extensions"). Must already exist.'
+    required: true
+  upstream-repo:
+    description: 'Upstream extensions repo'
+    default: 'zed-industries/extensions'
+  committer-token:
+    description: 'PAT with repo + workflow scopes on the fork. Used to push the bump branch and open/update the PR.'
+    required: true
+  signing-key:
+    description: 'Optional SSH private key (PEM-encoded) used to sign commits. The matching public key must be registered on the PAT owner''s GitHub account as a Signing Key (not an Authentication Key). If omitted, commits will be unsigned.'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Publish or update PR
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.committer-token }}
+        EXT_NAME: ${{ inputs.extension-name }}
+        VERSION: ${{ inputs.version }}
+        PUSH_TO: ${{ inputs.push-to }}
+        UPSTREAM: ${{ inputs.upstream-repo }}
+        SOURCE_REPO: ${{ github.repository }}
+        SIGNING_KEY: ${{ inputs.signing-key }}
+      run: bash ${{ github.action_path }}/publish.sh

--- a/.github/actions/publish-zed-extension/publish.sh
+++ b/.github/actions/publish-zed-extension/publish.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env (set by action.yml):
+#   GH_TOKEN, EXT_NAME, VERSION, PUSH_TO, UPSTREAM, SOURCE_REPO
+
+FORK_OWNER="${PUSH_TO%%/*}"
+BRANCH="bump-${EXT_NAME}-${VERSION}"
+SUBMODULE_PATH="extensions/${EXT_NAME}"
+
+echo "::notice::Publishing ${EXT_NAME} v${VERSION} via ${PUSH_TO} → ${UPSTREAM} (branch: ${BRANCH})"
+
+# Commit as the PAT owner so signed-CLA checks (e.g., Zed's cla-bot) resolve
+# to a real human rather than github-actions[bot], which can't sign a CLA.
+GIT_USER_LOGIN=$(gh api user --jq .login)
+GIT_USER_ID=$(gh api user --jq .id)
+GIT_USER_NAME=$(gh api user --jq '.name // .login')
+git config --global user.name "${GIT_USER_NAME}"
+git config --global user.email "${GIT_USER_ID}+${GIT_USER_LOGIN}@users.noreply.github.com"
+echo "::notice::Committing as ${GIT_USER_NAME} <${GIT_USER_ID}+${GIT_USER_LOGIN}@users.noreply.github.com>"
+
+EXISTING_PR=$(gh api "repos/${UPSTREAM}/pulls?state=open&head=${FORK_OWNER}:${BRANCH}" --jq '.[0].number // empty')
+if [[ -n "${EXISTING_PR}" ]]; then
+  echo "::notice::Found existing open PR #${EXISTING_PR} — branch will be force-updated"
+else
+  echo "::notice::No existing PR for ${BRANCH} — a new PR will be created"
+fi
+
+DEFAULT_BRANCH=$(gh repo view "${UPSTREAM}" --json defaultBranchRef --jq .defaultBranchRef.name)
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+git clone "https://x-access-token:${GH_TOKEN}@github.com/${PUSH_TO}.git" "${WORK_DIR}/fork"
+cd "${WORK_DIR}/fork"
+
+if [[ -n "${SIGNING_KEY:-}" ]]; then
+  SSH_KEY_FILE="${WORK_DIR}/signing-key"
+  printf '%s\n' "${SIGNING_KEY}" > "${SSH_KEY_FILE}"
+  chmod 600 "${SSH_KEY_FILE}"
+  git config --global gpg.format ssh
+  git config --global user.signingkey "${SSH_KEY_FILE}"
+  git config --global commit.gpgsign true
+  echo "::notice::SSH commit signing enabled"
+fi
+
+git remote add upstream "https://github.com/${UPSTREAM}.git"
+git fetch upstream "${DEFAULT_BRANCH}"
+
+# Sync the fork's default branch with upstream so the PR base is current.
+git checkout "${DEFAULT_BRANCH}"
+git reset --hard "upstream/${DEFAULT_BRANCH}"
+git push origin "${DEFAULT_BRANCH}"
+
+# Always rebuild the bump branch from a fresh upstream base — cleaner than
+# trying to rebase whatever was on the existing PR branch.
+git checkout -B "${BRANCH}" "upstream/${DEFAULT_BRANCH}"
+
+# Upstream's .gitmodules can record a stale submodule URL (e.g. after the
+# source repo moved to a new org). Force it to the current source repo so the
+# tag is fetched from the right place AND the bump PR carries the correction
+# upstream. Self-healing for any future transfer/rename.
+git config -f .gitmodules "submodule.${SUBMODULE_PATH}.url" "https://github.com/${SOURCE_REPO}.git"
+git submodule sync "${SUBMODULE_PATH}"
+
+git submodule update --init "${SUBMODULE_PATH}"
+SOURCE_TAG=""
+(
+  cd "${SUBMODULE_PATH}"
+  for candidate in "${VERSION}" "v${VERSION}"; do
+    if git ls-remote --tags origin "refs/tags/${candidate}" | grep -q .; then
+      echo "${candidate}" > /tmp/source-tag
+      break
+    fi
+  done
+  if [[ ! -s /tmp/source-tag ]]; then
+    echo "::error::No tag matching '${VERSION}' or 'v${VERSION}' found on $(git remote get-url origin)"
+    exit 1
+  fi
+  TAG="$(cat /tmp/source-tag)"
+  echo "::notice::Using source tag '${TAG}'"
+  git fetch --tags --depth 1 origin "refs/tags/${TAG}"
+  git checkout "${TAG}"
+)
+SOURCE_TAG="$(cat /tmp/source-tag)"
+rm -f /tmp/source-tag
+git add "${SUBMODULE_PATH}"
+git add .gitmodules
+
+# Update the version line within the [<ext_name>] section only.
+awk -v ext="${EXT_NAME}" -v ver="${VERSION}" '
+  /^\[/ { in_section = ($0 == "[" ext "]") }
+  in_section && /^version[[:space:]]*=/ {
+    print "version = \"" ver "\""
+    updated = 1
+    next
+  }
+  { print }
+  END { if (!updated) exit 1 }
+' extensions.toml > extensions.toml.new
+mv extensions.toml.new extensions.toml
+git add extensions.toml
+
+if git diff --cached --quiet; then
+  echo "::notice::No changes to commit — ${EXT_NAME} already at v${VERSION} with matching submodule SHA"
+  exit 0
+fi
+
+git commit -m "Bump ${EXT_NAME} to ${VERSION}
+
+Release notes:
+https://github.com/${SOURCE_REPO}/releases/tag/${SOURCE_TAG}"
+
+git push origin "${BRANCH}" --force
+
+if [[ -z "${EXISTING_PR}" ]]; then
+  gh pr create \
+    --repo "${UPSTREAM}" \
+    --head "${FORK_OWNER}:${BRANCH}" \
+    --base "${DEFAULT_BRANCH}" \
+    --title "Bump ${EXT_NAME} to ${VERSION}" \
+    --body "Bumps \`${EXT_NAME}\` to v${VERSION}.
+
+Release notes: https://github.com/${SOURCE_REPO}/releases/tag/${SOURCE_TAG}"
+  echo "::notice::Created new PR for ${EXT_NAME} v${VERSION}"
+else
+  echo "::notice::Force-pushed ${BRANCH} — PR #${EXISTING_PR} updated"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,16 +243,15 @@ jobs:
       - build-lsp-server
       - update-version
     steps:
-      - uses: huacnlee/zed-extension-action@v1
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Publish to zed-industries/extensions
+        uses: ./.github/actions/publish-zed-extension
         with:
           extension-name: phpcs
+          version: ${{ needs.update-version.outputs.new_version }}
           push-to: mike-bronner/extensions
-          tag-name: ${{ needs.update-version.outputs.new_version }}
-          commit-message: |
-            Update {{extensionName}} to {{version}}
-
-            Release notes:
-
-            https://github.com/{{owner}}/{{repo}}/releases/tag/{{version}}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.ZED_PUBLISHING_TOKEN }}
+          committer-token: ${{ secrets.ZED_PUBLISHING_TOKEN }}
+          signing-key: ${{ secrets.COMMIT_SIGNING_SSH_KEY }}


### PR DESCRIPTION
## 🎯 What

Replaces the third-party `huacnlee/zed-extension-action@v1` publish step with the in-repo composite action ported from [zed-laravel](https://github.com/mike-bronner/zed-laravel/tree/main/.github/actions/publish-zed-extension).

## 🤔 Why (flaws in the old action)

| | `huacnlee/zed-extension-action` | this action |
|---|---|---|
| `.gitmodules` URL | never touched → stale `GeneaLabs` URL persists (redirect-dependent) | **self-heals** the URL every release; bump PR carries the fix upstream |
| CLA | can author as `github-actions[bot]` → cla-bot blocks | commits as the **PAT owner** (signed human) |
| Signing | unsigned → "Unverified" | optional **SSH signing** → "Verified" |
| Supply chain | external action on mutable `@v1`, holding your PAT | **in-repo, auditable** |
| Re-runs | timestamp branch → **duplicate PRs** | version-keyed branch → **one PR per version** |
| Fork hygiene | leaves fork `main` to drift | resets fork `main` to mirror upstream |

The first row is the headline: it makes the org-transfer submodule-URL repoint **automatic on the next release** — no manual PR to `zed-industries/extensions` ever needed.

## 🔧 Changes
- Add `.github/actions/publish-zed-extension/` (`action.yml`, `publish.sh`, `README.md`)
- Swap the `publish` job in `release.yml` to use the local action (`extension-name: phpcs`, `push-to: mike-bronner/extensions`, `committer-token` + `signing-key`)

## ✅ Validated
- `bash -n publish.sh` clean; `release.yml` + `action.yml` parse as valid YAML
- phpcs's unprefixed tags (`0.4.1`) handled — `publish.sh` tries both `<ver>` and `v<ver>`
- ⚠️ Verified commits need `COMMIT_SIGNING_SSH_KEY` available to this repo (org secret); without it, publishing still works, just unsigned

Refs mike-bronner/zed-laravel#36