### PR TITLE
fix: 🐛 support Windows phpcs spawning and honor explicit phpcs_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,13 @@ export PHPCBF_PATH="/custom/path/to/phpcbf"
 
 The extension finds PHPCS and PHPCBF in this priority order:
 
-1. **Project composer** - `vendor/bin/phpcs` (includes project dependencies like Slevomat)
-2. **User-configured path** - Custom path from Zed LSP settings
+1. **User-configured path** - Custom path from Zed LSP settings (explicit override always wins)
+2. **Project composer** - `vendor/bin/phpcs` (includes project dependencies like Slevomat)
 3. **Environment variable** - `PHPCS_PATH` / `PHPCBF_PATH`
 4. **System PATH** - Global phpcs installation (respects your `phpcs --config-set` settings)
 5. **Bundled PHAR** - Modern PHPCS v3.13.2+ (fallback, included with extension)
+
+> **🪟 Windows:** Composer's `vendor/bin/phpcs` and the bundled `.phar` are PHP scripts, not native executables, so they're launched through `php` automatically; `.bat`/`.cmd` wrappers run via `cmd /C`. Ensure `php` is on your `PATH`.
 
 > **💡 Global Config Support:** The extension now respects your system PHPCS configuration. Set global defaults with `phpcs --config-set default_standard PSR12` or `phpcs --config-set installed_paths /path/to/sniffs` and they'll work automatically without any Zed configuration.
 
@@ -350,7 +352,7 @@ Use PHPCS fixing alongside a separate formatter (e.g., Prettier for embedded HTM
 ### How It Works
 
 - Auto-fixing uses the same coding standard as linting (phpcs.xml discovery, Zed settings, etc.)
-- PHPCBF is discovered automatically using the same priority as PHPCS: project `vendor/bin` → user-configured path → `PHPCBF_PATH` env var → system PATH → bundled PHAR
+- PHPCBF is discovered automatically using the same priority as PHPCS: user-configured path → project `vendor/bin` → `PHPCBF_PATH` env var → system PATH → bundled PHAR
 - Auto-fixing and linting run from the same LSP process — no extra configuration needed
 - The `source.fixAll.phpcs` code action is also available in the lightbulb menu for manual use
 

--- a/lsp-server/Cargo.lock
+++ b/lsp-server/Cargo.lock
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -231,10 +249,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "httparse"
@@ -324,6 +376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,16 +403,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -370,6 +452,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lsp-types"
@@ -455,6 +543,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -499,6 +588,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +614,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -555,10 +660,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -683,6 +807,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -869,6 +1006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1049,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1113,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/lsp-server/Cargo.toml
+++ b/lsp-server/Cargo.toml
@@ -22,3 +22,4 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+tempfile = "3.22"

--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -121,6 +121,19 @@ fn generate_phpcs_doc_url(source: &str) -> Option<Url> {
     Url::parse(&url_str).ok()
 }
 
+/// Build a process command for a resolved PHP-tool path, applying the
+/// platform-specific spawn strategy from [`tools::plan_spawn`]. On Windows this
+/// routes the Composer `vendor/bin` proxy and `*.phar` files through `php`, and
+/// `.bat`/`.cmd` wrappers through `cmd /C`, instead of spawning them directly
+/// (which fails with `os error 193`). The caller appends the tool's own
+/// arguments afterwards.
+fn build_tool_command(tool_path: &str) -> ProcessCommand {
+    let plan = tools::plan_spawn(tool_path, cfg!(windows));
+    let mut cmd = ProcessCommand::new(&plan.program);
+    cmd.args(&plan.prefix_args);
+    cmd
+}
+
 impl PhpcsLanguageServer {
     fn new(client: Client) -> Self {
         Self {
@@ -238,7 +251,7 @@ impl PhpcsLanguageServer {
 
         let phpcbf_path = self.get_phpcbf_path();
 
-        let mut cmd = ProcessCommand::new(&phpcbf_path);
+        let mut cmd = build_tool_command(&phpcbf_path);
         cmd.arg("--no-colors")
            .arg("-q");
 
@@ -410,7 +423,7 @@ impl PhpcsLanguageServer {
         }
 
         let text = content.unwrap();
-        let mut cmd = ProcessCommand::new(&phpcs_path);
+        let mut cmd = build_tool_command(&phpcs_path);
         cmd.arg("--report=json")
            .arg("--no-colors")
            .arg("-q");

--- a/lsp-server/src/tools.rs
+++ b/lsp-server/src/tools.rs
@@ -64,17 +64,30 @@ pub fn command_exists(cmd: &str) -> bool {
 }
 
 /// Detect the path to a PHP tool using the following priority:
-/// 1. Project vendor/bin/{tool} (project-local Composer install)
-/// 2. User-configured path from LSP settings
+/// 1. User-configured path from LSP settings (explicit override wins)
+/// 2. Project vendor/bin/{tool} (project-local Composer install)
 /// 3. Environment variable (PHPCS_PATH / PHPCBF_PATH)
 /// 4. System {tool} (in PATH)
 /// 5. Bundled {tool}.phar
 /// 6. Fallback to tool name (will fail at runtime if not found)
+///
+/// The user-configured path is checked first so that an explicit `phpcs_path`
+/// setting always takes effect — e.g. on Windows, where the Composer-generated
+/// `vendor/bin/phpcs` proxy cannot be spawned directly and a user must point at
+/// a working binary. See `plan_spawn` for how the resolved path is executed.
 pub fn detect_tool_path(tool: PhpTool, workspace_root: Option<&Path>, user_path: Option<&str>) -> String {
     let display = tool.display_name();
     let name = tool.name();
 
-    // Priority 1: Project vendor/bin
+    // Priority 1: User-configured path (explicit override wins over auto-detection)
+    if let Some(path) = user_path {
+        if !path.trim().is_empty() {
+            eprintln!("🎯 PHPCS LSP: Using user-configured {} path: {}", display, path);
+            return path.to_string();
+        }
+    }
+
+    // Priority 2: Project vendor/bin
     if let Some(workspace_root) = workspace_root {
         let vendor_path = workspace_root.join(tool.vendor_bin());
         eprintln!(
@@ -88,14 +101,6 @@ pub fn detect_tool_path(tool: PhpTool, workspace_root: Option<&Path>, user_path:
             return vendor_path.to_string_lossy().to_string();
         }
         eprintln!("❌ PHPCS LSP: No project-local {} found", display);
-    }
-
-    // Priority 2: User-configured path
-    if let Some(path) = user_path {
-        if !path.trim().is_empty() {
-            eprintln!("🎯 PHPCS LSP: Using user-configured {} path: {}", display, path);
-            return path.to_string();
-        }
     }
 
     // Priority 3: Environment variable
@@ -141,4 +146,208 @@ pub fn detect_tool_path(tool: PhpTool, workspace_root: Option<&Path>, user_path:
         display, name
     );
     name.to_string()
+}
+
+/// How to spawn a resolved tool path: the program to launch and any arguments
+/// that must precede the tool's own arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnPlan {
+    pub program: String,
+    pub prefix_args: Vec<String>,
+}
+
+/// Decide how to spawn a resolved tool path on a given platform.
+///
+/// On Unix the path is launched directly — Composer's `vendor/bin` proxy and the
+/// bundled `*.phar` both carry a `#!/usr/bin/env php` shebang and the executable
+/// bit, so the kernel runs them via PHP.
+///
+/// Windows has no shebang mechanism, and `CreateProcess` only accepts real PE
+/// executables, so launching the proxy or a `.phar` directly fails with
+/// `os error 193` ("%1 is not a valid Win32 application"). Dispatch by kind:
+/// - `.exe` → launch directly.
+/// - `.bat` / `.cmd` → launch via `cmd /C` (batch files require the interpreter).
+/// - a path to anything else (the extensionless Composer proxy, `*.phar`) → run
+///   it through `php <path>`.
+/// - a bare command name with no path separator (e.g. a system `phpcs` on PATH)
+///   → `cmd /C <name>` so the shell can resolve a `.bat`/`.exe` on PATH.
+pub fn plan_spawn(tool_path: &str, is_windows: bool) -> SpawnPlan {
+    if !is_windows {
+        return SpawnPlan {
+            program: tool_path.to_string(),
+            prefix_args: Vec::new(),
+        };
+    }
+
+    let extension = Path::new(tool_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+
+    match extension.as_deref() {
+        Some("exe") => SpawnPlan {
+            program: tool_path.to_string(),
+            prefix_args: Vec::new(),
+        },
+        Some("bat") | Some("cmd") => SpawnPlan {
+            program: "cmd".to_string(),
+            prefix_args: vec!["/C".to_string(), tool_path.to_string()],
+        },
+        _ => {
+            let has_separator = tool_path.contains('/') || tool_path.contains('\\');
+            if has_separator {
+                // A path to a Composer proxy script or a `.phar` — run it via PHP.
+                SpawnPlan {
+                    program: "php".to_string(),
+                    prefix_args: vec![tool_path.to_string()],
+                }
+            } else {
+                // A bare command name — let cmd resolve it on PATH (it may be a `.bat`).
+                SpawnPlan {
+                    program: "cmd".to_string(),
+                    prefix_args: vec!["/C".to_string(), tool_path.to_string()],
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn direct(path: &str) -> SpawnPlan {
+        SpawnPlan {
+            program: path.to_string(),
+            prefix_args: Vec::new(),
+        }
+    }
+
+    fn via_cmd(path: &str) -> SpawnPlan {
+        SpawnPlan {
+            program: "cmd".to_string(),
+            prefix_args: vec!["/C".to_string(), path.to_string()],
+        }
+    }
+
+    fn via_php(path: &str) -> SpawnPlan {
+        SpawnPlan {
+            program: "php".to_string(),
+            prefix_args: vec![path.to_string()],
+        }
+    }
+
+    #[test]
+    fn unix_always_launches_directly() {
+        // On Unix every kind of path is spawned as-is (shebang + exec bit do the work).
+        for path in [
+            "vendor/bin/phpcs",
+            "/usr/local/bin/phpcs.phar",
+            "phpcs",
+            "/some/phpcs.bat",
+        ] {
+            assert_eq!(plan_spawn(path, false), direct(path), "path: {path}");
+        }
+    }
+
+    #[test]
+    fn windows_runs_exe_directly() {
+        assert_eq!(
+            plan_spawn(r"C:\tools\phpcs.exe", true),
+            direct(r"C:\tools\phpcs.exe")
+        );
+    }
+
+    #[test]
+    fn windows_routes_bat_and_cmd_through_cmd() {
+        assert_eq!(
+            plan_spawn(r"C:\proj\vendor\bin\phpcs.bat", true),
+            via_cmd(r"C:\proj\vendor\bin\phpcs.bat")
+        );
+        assert_eq!(
+            plan_spawn(r"C:\proj\vendor\bin\phpcs.cmd", true),
+            via_cmd(r"C:\proj\vendor\bin\phpcs.cmd")
+        );
+    }
+
+    #[test]
+    fn windows_runs_composer_proxy_through_php() {
+        // The extensionless Composer proxy (issue #60's failing case) → `php <path>`.
+        assert_eq!(
+            plan_spawn(r"C:\proj\vendor/bin/phpcs", true),
+            via_php(r"C:\proj\vendor/bin/phpcs")
+        );
+        assert_eq!(
+            plan_spawn(r"C:\proj\vendor\bin\phpcs", true),
+            via_php(r"C:\proj\vendor\bin\phpcs")
+        );
+    }
+
+    #[test]
+    fn windows_runs_phar_through_php() {
+        assert_eq!(
+            plan_spawn(r"C:\Users\me\.phpcs\phpcs.phar", true),
+            via_php(r"C:\Users\me\.phpcs\phpcs.phar")
+        );
+    }
+
+    #[test]
+    fn windows_resolves_bare_command_through_cmd() {
+        // A bare name (system PATH lookup) → cmd so a `.bat`/`.exe` on PATH resolves.
+        assert_eq!(plan_spawn("phpcs", true), via_cmd("phpcs"));
+    }
+
+    #[test]
+    fn windows_extension_matching_is_case_insensitive() {
+        assert_eq!(plan_spawn(r"C:\t\phpcs.EXE", true), direct(r"C:\t\phpcs.EXE"));
+        assert_eq!(plan_spawn(r"C:\t\phpcs.BAT", true), via_cmd(r"C:\t\phpcs.BAT"));
+        assert_eq!(plan_spawn(r"C:\t\phpcs.Phar", true), via_php(r"C:\t\phpcs.Phar"));
+    }
+
+    #[test]
+    fn user_path_takes_precedence_over_vendor_bin() {
+        // Regression for issue #60: an explicit phpcs_path must win even when a
+        // project-local vendor/bin/phpcs exists.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let vendor_bin = tmp.path().join("vendor").join("bin");
+        fs::create_dir_all(&vendor_bin).expect("create vendor/bin");
+        fs::write(vendor_bin.join("phpcs"), "#!/usr/bin/env php\n").expect("write proxy");
+
+        let resolved = detect_tool_path(
+            PhpTool::Phpcs,
+            Some(tmp.path()),
+            Some(r"C:\custom\phpcs.bat"),
+        );
+
+        assert_eq!(resolved, r"C:\custom\phpcs.bat");
+    }
+
+    #[test]
+    fn vendor_bin_is_used_when_no_user_path() {
+        // Without a user path, the project-local vendor/bin install is preferred.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let vendor_bin = tmp.path().join("vendor").join("bin");
+        fs::create_dir_all(&vendor_bin).expect("create vendor/bin");
+        let proxy = vendor_bin.join("phpcs");
+        fs::write(&proxy, "#!/usr/bin/env php\n").expect("write proxy");
+
+        let resolved = detect_tool_path(PhpTool::Phpcs, Some(tmp.path()), None);
+
+        assert_eq!(resolved, proxy.to_string_lossy());
+    }
+
+    #[test]
+    fn blank_user_path_is_ignored() {
+        // A whitespace-only setting should fall through to vendor/bin, not win.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let vendor_bin = tmp.path().join("vendor").join("bin");
+        fs::create_dir_all(&vendor_bin).expect("create vendor/bin");
+        let proxy = vendor_bin.join("phpcs");
+        fs::write(&proxy, "#!/usr/bin/env php\n").expect("write proxy");
+
+        let resolved = detect_tool_path(PhpTool::Phpcs, Some(tmp.path()), Some("   "));
+
+        assert_eq!(resolved, proxy.to_string_lossy());
+    }
 }


### PR DESCRIPTION
Fixes #60

## Problem

On Windows the LSP server starts but fails to lint with:

```
❌ PHPCS LSP: Failed to spawn PHPCS for File.php: %1 is not a valid Win32 application. (os error 193)
```

…and an explicit `phpcs_path` setting has no effect. Two distinct root causes:

1. **`phpcs_path` was ignored.** `detect_tool_path` checked the project `vendor/bin` install **before** the user-configured path, so an explicit `phpcs_path` never took effect when `vendor/bin/phpcs` existed (always true in a Composer project).
2. **Spawning failed with `os error 193`.** Composer's `vendor/bin/phpcs` proxy and the bundled `.phar` are PHP scripts, not PE executables — Windows `CreateProcess` cannot launch them directly. (The bundled `.phar` fallback had the same latent bug.)

## Fix (Option 1)

- **Reorder `detect_tool_path`** so the user-configured path wins over auto-detection: user path → `vendor/bin` → env var → system PATH → bundled PHAR.
- **Add `plan_spawn`**, a pure, per-platform spawn-strategy function:
  - Unix → launch directly (shebang + exec bit).
  - Windows `.exe` → launch directly.
  - Windows `.bat`/`.cmd` → `cmd /C <path>`.
  - Windows script/`.phar` (path) → `php <path>`.
  - Windows bare command name → `cmd /C <name>` (PATH resolution).
- `run_phpcs` and `run_phpcbf` both build their command through a shared `build_tool_command` helper.

## Tests

- 7 `plan_spawn` cases covering every path kind on both platforms (incl. case-insensitive extensions). Windows behavior is verified cross-platform via the explicit `is_windows` parameter.
- 3 `detect_tool_path` cases proving the new priority order (user path wins, vendor/bin used otherwise, blank path ignored).
- `cargo test` → 10 passed. `cargo clippy -- -D warnings` → clean.

## Notes

- ⚠️ This lives in the LSP server binary, which Windows users download by version tag from Releases — the fix reaches them only after a **new release is cut** (rebuilds the Windows binaries).
- 🪟 The `php`-wrapping assumes `php` is on `PATH` (already true today for the bundled-`.phar` shebang path on Unix). Documented in the README.
- 🙏 A real-Windows smoke test by the reporter (@hmhofman) would be ideal before release.