### PR TITLE
Workaround for Zed code_actions_on_format revert when no formatter configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Use PHPCS fixing alongside a separate formatter (e.g., Prettier for embedded HTM
 }
 ```
 
-> **Important:** When using `code_actions_on_format` without a separate formatter, you must set `"formatter": []` to prevent Zed's default `"auto"` formatter from interfering. See [zed-industries/zed#51490](https://github.com/zed-industries/zed/issues/51490) for details.
+> **Important:** When using `code_actions_on_format` without a separate formatter, you must set `"formatter": []` to prevent Zed's default `"auto"` formatter from reverting the applied fixes. This is a workaround for [zed-industries/zed#51490](https://github.com/zed-industries/zed/issues/51490); once that issue is resolved — or [zed-industries/zed#48991](https://github.com/zed-industries/zed/pull/48991) lands, adding support for `"formatter": "none"` — the `"formatter": []` workaround will no longer be needed and can be removed from your settings.
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ if ($x === 1) {
 }
 ```
 
-> **Note:** This runs PHPCBF on every save, automatically fixing all fixable code style issues. The `"formatter": []` is required to prevent Zed's default formatter from interfering. See the [Auto-Fix on Save](#auto-fix-on-save) section for more configuration options.
+> **Note:** This runs PHPCBF on every save, automatically fixing all fixable code style issues. The `"formatter": []` is required to prevent Zed's default formatter from reverting the applied fixes. See the [Auto-Fix on Save](#auto-fix-on-save) section for more configuration options.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
Implements #56 — docs-only, per the rescoped acceptance criteria (the `documentFormattingProvider` formatter approach was intentionally removed in b69c81b and is **not** re-introduced).

## Changes
- The Auto-Fix on Save `"formatter": []` callout now links **both** upstream references: [zed-industries/zed#51490](https://github.com/zed-industries/zed/issues/51490) and [zed-industries/zed#48991](https://github.com/zed-industries/zed/pull/48991) (the PR adding `"formatter": "none"`).
- The callout states the `"formatter": []` workaround can be removed once either upstream change is resolved.
- Wording tightened: "interfering" → "reverting the applied fixes", matching the actual failure mode.
- Quick-start note (README.md:88) aligned to the same wording, per review feedback on this PR.

## Acceptance Criteria
- [x] The Auto-Fix on Save section's `"formatter": []` callout links both zed-industries/zed#51490 and zed-industries/zed#48991 as upstream context
- [x] The note states that the `"formatter": []` workaround can be removed once either upstream issue is resolved
- [x] README does not document a formatter approach via `documentFormattingProvider` — not re-introduced (verified by grep; only the unrelated `language_servers` enablement mentions language servers)
- [x] A user following the README can configure auto-fix on save (`source.fixAll.phpcs` + `"formatter": []` + `"format_on_save": "on"`) without reverts — config blocks in the Auto-Fix on Save section and quick-start are unchanged and complete

## Test Plan
- [x] Docs-only change — no code paths affected; `documentFormattingProvider` confirmed absent from README via grep
- [x] CI (test + fmt + clippy + wasm check) passes on the branch

Fixes #56