### PR TITLE
fix: 🐛 Prevent stale PHPCS diagnostics from sticking after edits

### DIFF
--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -1231,6 +1231,7 @@ impl LanguageServer for PhpcsLanguageServer {
         eprintln!("🔄 PHPCS LSP: Configuration change detected!");
 
         let mut path_changed = false;
+        let mut standard_changed = false;
 
         // Parse the settings
         if let Some(settings) = params.settings.as_object() {
@@ -1247,6 +1248,9 @@ impl LanguageServer for PhpcsLanguageServer {
                             new_standard
                         );
                         if let Ok(mut standard_guard) = self.standard.write() {
+                            if tools::value_changed(standard_guard.as_deref(), &new_standard) {
+                                standard_changed = true;
+                            }
                             *standard_guard = Some(new_standard);
                         }
                     }
@@ -1284,6 +1288,9 @@ impl LanguageServer for PhpcsLanguageServer {
             if let Some(standard_value) = settings.get("standard") {
                 if let Some(new_standard) = standard_value.as_str() {
                     if let Ok(mut standard_guard) = self.standard.write() {
+                        if tools::value_changed(standard_guard.as_deref(), new_standard) {
+                            standard_changed = true;
+                        }
                         *standard_guard = Some(new_standard.to_string());
                     }
                 }
@@ -1327,10 +1334,17 @@ impl LanguageServer for PhpcsLanguageServer {
             }
         }
 
-        // Clear results cache to force re-linting with new config
-        if let Ok(mut cache) = self.results_cache.write() {
-            cache.clear();
-            eprintln!("🗑️ PHPCS LSP: Cleared results cache after config change");
+        // Clear the results cache only when the effective config actually changed.
+        // Cached diagnostics depend on the resolved tool path and the active
+        // standard, so a real change to either invalidates them — but a no-op
+        // notification that merely restates the current settings must not wipe the
+        // cache and force redundant re-lints.
+        let config_changed = path_changed || standard_changed;
+        if config_changed {
+            if let Ok(mut cache) = self.results_cache.write() {
+                cache.clear();
+                eprintln!("🗑️ PHPCS LSP: Cleared results cache after config change");
+            }
         }
 
         // Note: Documents will be re-linted on next diagnostic() call
@@ -1502,14 +1516,36 @@ impl LanguageServer for PhpcsLanguageServer {
                             file_name
                         );
 
-                        // Cache the results
-                        let cached_results = CachedResults {
-                            diagnostics: diagnostics.clone(),
-                            result_id: version_id.clone(),
+                        // Cache the results — but only if this lint still reflects
+                        // the document's current content. run_phpcs runs behind a
+                        // semaphore while diagnostic requests dispatch concurrently,
+                        // so a slow lint of an older version can finish after a fast
+                        // lint of a newer one; writing it anyway would clobber the
+                        // fresher entry with stale diagnostics (the "stuck results"
+                        // bug). Re-read the current checksum and gate the write.
+                        let current_checksum = {
+                            let docs = self.open_docs.read().unwrap();
+                            docs.get(&uri).map(|doc| doc.checksum.clone())
                         };
 
-                        if let Ok(mut cache) = self.results_cache.write() {
-                            cache.insert(uri.clone(), cached_results);
+                        let store = current_checksum.as_deref().is_some_and(|current| {
+                            tools::should_store_result(current, &version_id)
+                        });
+
+                        if store {
+                            let cached_results = CachedResults {
+                                diagnostics: diagnostics.clone(),
+                                result_id: version_id.clone(),
+                            };
+
+                            if let Ok(mut cache) = self.results_cache.write() {
+                                cache.insert(uri.clone(), cached_results);
+                            }
+                        } else {
+                            eprintln!(
+                                "🗑️ PHPCS LSP: Dropped stale PHPCS result for {} (document changed during lint)",
+                                file_name
+                            );
                         }
 
                         return Ok(DocumentDiagnosticReportResult::Report(

--- a/lsp-server/src/tools.rs
+++ b/lsp-server/src/tools.rs
@@ -222,6 +222,29 @@ pub fn plan_spawn(tool_path: &str, is_windows: bool) -> SpawnPlan {
     }
 }
 
+/// Whether a freshly-computed PHPCS result may be written to the results cache.
+///
+/// `run_phpcs` executes behind a semaphore while tower-lsp dispatches diagnostic
+/// requests concurrently, so a slow lint of an older document version can finish
+/// *after* a fast lint of a newer one. The result is only safe to cache when the
+/// content it was computed against (`linted_checksum`) still matches the
+/// document's current checksum (`current_checksum`); otherwise the document
+/// changed mid-lint and the result is stale — dropping it leaves the fresher
+/// cache entry intact instead of clobbering it with old diagnostics.
+pub fn should_store_result(current_checksum: &str, linted_checksum: &str) -> bool {
+    current_checksum == linted_checksum
+}
+
+/// Whether an incoming configuration value actually differs from the stored one.
+///
+/// A `did_change_configuration` notification may merely restate the current
+/// settings; treating that no-op as a change would needlessly wipe caches and
+/// force redundant re-lints. `None` (unset) versus any concrete value counts as
+/// a change, so the first time a value is set is detected correctly.
+pub fn value_changed(old: Option<&str>, new: &str) -> bool {
+    old != Some(new)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -322,6 +345,32 @@ mod tests {
             plan_spawn(r"C:\t\phpcs.Phar", true),
             via_php(r"C:\t\phpcs.Phar")
         );
+    }
+
+    #[test]
+    fn stores_result_when_checksum_still_current() {
+        // The version PHPCS linted is still the document's current version — cache it.
+        assert!(should_store_result("abc123", "abc123"));
+    }
+
+    #[test]
+    fn drops_result_when_document_changed_during_lint() {
+        // The document moved on while PHPCS ran — the result is stale, drop it so a
+        // fresher cache entry is not overwritten.
+        assert!(!should_store_result("newchecksum", "oldchecksum"));
+    }
+
+    #[test]
+    fn value_changed_detects_a_real_change() {
+        // A different value, or the first time a value is set, is a real change.
+        assert!(value_changed(Some("PSR12"), "PSR2"));
+        assert!(value_changed(None, "PSR12"));
+    }
+
+    #[test]
+    fn value_changed_ignores_a_restated_value() {
+        // Re-sending the same standard must not count as a change.
+        assert!(!value_changed(Some("PSR12"), "PSR12"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PHPCS diagnostics in Zed get "stuck" on stale results after a file changes — they only refresh on the next keystroke.

**Root cause:** `diagnostic()` wrote every freshly-computed lint into `results_cache` without checking that the linted content was still current. Because `run_phpcs` runs behind a 4-permit semaphore while tower-lsp dispatches request handlers concurrently, a slow lint of an *old* document version could finish *after* a fast lint of a *new* version and overwrite the cache with stale diagnostics. The pull-diagnostics `Unchanged` branch then kept serving them until the next `did_change` invalidated the entry.

The unconditional `results_cache.clear()` in `did_change_configuration` amplified this: every notification (even a no-op restating current settings) wiped the cache and forced redundant concurrent re-lints, widening the race window.

## Changes

- **Guard the cache write** — before storing, re-read the document's current checksum from `open_docs` and only cache when it still equals the just-linted `version_id`; otherwise drop the stale result and leave the fresher entry intact.
- **Gate the config-change clear** — clear the results cache only when the effective config actually changed (`path_changed || standard_changed`), instead of on every notification.
- Both decisions extracted into pure helpers in `tools.rs` (`should_store_result`, `value_changed`) with unit tests.

## Known limitation

The guard shrinks the race window from seconds (the whole PHPCS subprocess) to nanoseconds (a few synchronous instructions between the checksum read and the cache insert). A fully airtight fix would need a per-URI generation counter; that was deliberately scoped out as over-engineering for the bug being fixed.

## Verification

- `cargo build` — clean
- `cargo test` — 14 passed (10 pre-existing + 4 new)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 warnings
